### PR TITLE
Update to Zig 0.12.0-dev.1092+68ed78775

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -92,7 +92,7 @@ pub fn build(b: *std.Build) !void {
         }
     }
 
-    lib.addCSourceFiles(srcs, flags.items);
+    lib.addCSourceFiles(.{ .files = srcs, .flags = flags.items });
     lib.installHeader("override/include/libxml/xmlversion.h", "libxml/xmlversion.h");
     lib.installHeadersDirectory("upstream/include/libxml", "libxml");
 


### PR DESCRIPTION
This build.zig update is needed to make it work on a recent Zig master.  Thanks for this work @mitchellh!